### PR TITLE
Add Support for category 'tgq' dimmer.

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ class TuyaPlatform {
         break;
       case 'dj':
       case 'fwd':
+      case 'tgq':
       case 'xdd':
         deviceAccessory = new LightAccessory(this, homebridgeAccessory, device);
         this.accessories.set(uuid, deviceAccessory.homebridgeAccessory);

--- a/lib/light_accessory.js
+++ b/lib/light_accessory.js
@@ -35,23 +35,23 @@ class LightAccessory extends BaseAccessory {
     this.refreshAccessoryServiceIfNeed(this.statusArr, false);
   }
 
-  //init Or refresh AccessoryService
+   //init Or refresh AccessoryService
   refreshAccessoryServiceIfNeed(statusArr, isRefesh) {
     this.isRefesh = isRefesh;
     for (var statusMap of statusArr) {
       if (statusMap.code === 'work_mode') {
         this.workMode = statusMap;
       }
-      if (statusMap.code === 'switch_led') {
+      if (statusMap.code === 'switch_led' || statusMap.code === 'switch_led_1') {
         this.switchLed = statusMap;
         this.normalAsync(Characteristic.On, this.switchLed.value, this.isRefesh)
       }
-      if (statusMap.code === 'bright_value' || statusMap.code === 'bright_value_v2') {
+      if (statusMap.code === 'bright_value' || statusMap.code === 'bright_value_v2' || statusMap.code === 'bright_value_1') {
         this.brightValue = statusMap;
         var rawValue;
         var percentage;
         rawValue = this.brightValue.value;
-        percentage = Math.floor((rawValue - this.function_dp_range.bright_range.min) * 100 / (this.function_dp_range.bright_range.max - this.function_dp_range.bright_range.min)); //    percentage 0~100
+        percentage = Math.floor((rawValue - this.function_dp_range.bright_range.min) * 100 / (this.function_dp_range.bright_range.max - this.function_dp_range.bright_range.min)); //    $
         this.normalAsync(Characteristic.Brightness, percentage > 100 ? 100 : percentage, this.isRefesh)
       }
       if (statusMap.code === 'temp_value' || statusMap.code === 'temp_value_v2') {
@@ -59,7 +59,7 @@ class LightAccessory extends BaseAccessory {
         var rawValue;
         var temperature;
         rawValue = this.tempValue.value;
-        temperature = Math.floor((rawValue - this.function_dp_range.temp_range.min) * 360 / (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) + 140); // rawValue  0~1000  temperature 140~500
+        temperature = Math.floor((rawValue - this.function_dp_range.temp_range.min) * 360 / (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) + 140); // ra$
         if (temperature > 500) {
           temperature = 500
         }
@@ -75,12 +75,11 @@ class LightAccessory extends BaseAccessory {
         this.normalAsync(Characteristic.Hue, hue, this.isRefesh)
 
         var saturation;
-        saturation = Math.floor((this.colourObj.s - this.function_dp_range.saturation_range.min) * 100 / (this.function_dp_range.saturation_range.max - this.function_dp_range.saturation_range.min));  // saturation 0-100
+        saturation = Math.floor((this.colourObj.s - this.function_dp_range.saturation_range.min) * 100 / (this.function_dp_range.saturation_range.max - this.function_dp_range.saturation$
         this.normalAsync(Characteristic.Saturation, saturation > 100 ? 100 : saturation, this.isRefesh)
       }
     }
   }
-
 
   normalAsync(name, hbValue, isRefresh) {
     this.setCachedState(name, hbValue);
@@ -93,7 +92,7 @@ class LightAccessory extends BaseAccessory {
     }
 }
 
-  getAccessoryCharacteristic(name) {
+getAccessoryCharacteristic(name) {
     //set  Accessory service Characteristic
     this.service.getCharacteristic(name)
       .on('get', callback => {
@@ -123,15 +122,21 @@ class LightAccessory extends BaseAccessory {
       });
   }
 
-  //get Command SendData
+//get Command SendData
   getSendParam(name, value) {
     var code;
     var value;
     switch (name) {
-      case Characteristic.On:
+      case Characteristic.On:{
         const isOn = value ? true : false;
-        code = "switch_led";
+        if (this.deviceCategorie == 'tgq') {
+        code = "switch_led_1";
         value = isOn;
+        } else {
+          code = "switch_led";
+          value = isOn;
+        }
+    }
         break;
       case Characteristic.ColorTemperature:
         var temperature;
@@ -194,12 +199,15 @@ class LightAccessory extends BaseAccessory {
         case 'bright_value':
           if (this.deviceCategorie == 'dj') {
             defaultBrightRange = { 'min': 25, 'max': 255 }
-          }else if (this.deviceCategorie == 'xdd' || this.deviceCategorie == 'fwd') {
+          }else if (this.deviceCategorie == 'xdd' || this.deviceCategorie == 'fwd' || this.deviceCategorie == 'tgq') {
             defaultBrightRange = { 'min': 10, 'max': 1000 }
           }
           break;
         case 'bright_value_v2':
           defaultBrightRange = { 'min': 10, 'max': 1000 }
+          break;
+        case 'bright_value_1':
+           defaultBrightRange = { 'min':10, 'max':1000 }
           break;
         case 'temp_value':
           if (this.deviceCategorie == 'dj') {

--- a/lib/light_accessory.js
+++ b/lib/light_accessory.js
@@ -75,7 +75,7 @@ class LightAccessory extends BaseAccessory {
         this.normalAsync(Characteristic.Hue, hue, this.isRefesh)
 
         var saturation;
-        saturation = Math.floor((this.colourObj.s - this.function_dp_range.saturation_range.min) * 100 / (this.function_dp_range.saturation_range.max - this.function_dp_range.saturation$
+        saturation = Math.floor((this.colourObj.s - this.function_dp_range.saturation_range.min) * 100 / (this.function_dp_range.saturation_range.max - this.function_dp_range.saturation_range.min));  // saturation 0-100
         this.normalAsync(Characteristic.Saturation, saturation > 100 ? 100 : saturation, this.isRefesh)
       }
     }
@@ -127,16 +127,10 @@ getAccessoryCharacteristic(name) {
     var code;
     var value;
     switch (name) {
-      case Characteristic.On:{
+     case Characteristic.On:
         const isOn = value ? true : false;
-        if (this.deviceCategorie == 'tgq') {
-        code = "switch_led_1";
+        code = this.switchLed.code;
         value = isOn;
-        } else {
-          code = "switch_led";
-          value = isOn;
-        }
-    }
         break;
       case Characteristic.ColorTemperature:
         var temperature;
@@ -203,11 +197,9 @@ getAccessoryCharacteristic(name) {
             defaultBrightRange = { 'min': 10, 'max': 1000 }
           }
           break;
+        case 'bright_value_1':
         case 'bright_value_v2':
           defaultBrightRange = { 'min': 10, 'max': 1000 }
-          break;
-        case 'bright_value_1':
-           defaultBrightRange = { 'min':10, 'max':1000 }
           break;
         case 'temp_value':
           if (this.deviceCategorie == 'dj') {


### PR DESCRIPTION
I updated from the latest commit and added in support for the category 'tgq.' My devices are outdoor dimmer lights, supporting only brightness. 

In order to support I had to add in logic for "led_switch_1" and "bright_value_1." It is working in my testing without negatively impacting my 'dj' devices.

Please review. If you want to refactor the code in a way that you prefer that is fine too.