### PR TITLE
Fix inversed colour temperature.

### DIFF
--- a/lib/light_accessory.js
+++ b/lib/light_accessory.js
@@ -56,12 +56,12 @@ class LightAccessory extends BaseAccessory {
         var rawValue;
         var temperature;
         rawValue = this.tempValue.value;
-        temperature = Math.floor((rawValue - this.function_dp_range.temp_range.min) * 360 / (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) + 140); // ra$
+        temperature = Math.floor(1000000/((rawValue - this.function_dp_range.temp_range.min) * 12285 / (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) + 2000)); // ra$
         if (temperature > 500) {
-          temperature = 500
+          temperature = 500;
         }
-        if (temperature < 140) {
-          temperature = 140
+        if (temperature < 70) {
+          temperature = 70;
         }
         this.normalAsync(Characteristic.ColorTemperature, temperature)
       }
@@ -123,6 +123,11 @@ class LightAccessory extends BaseAccessory {
           callback(error);
         });
       });
+    
+    //Extend the range of the ColorTemperature characteristic so the UI will show a better looking orange to blue gradient.
+    if (name == Characteristic.ColorTemperature) {
+	    this.service.getCharacteristic(name).setProps({minValue:70,maxValue:500});
+    }
   }
 
   //get Command SendData
@@ -137,7 +142,7 @@ class LightAccessory extends BaseAccessory {
         break;
       case Characteristic.ColorTemperature:
         var temperature;
-        temperature = Math.floor((value - 140) * (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) / 360 + this.function_dp_range.temp_range.min); // value 140~500
+        temperature = Math.floor((1000000/value - 2000) * (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) / 12285 + this.function_dp_range.temp_range.min); // value 70~500
         code = this.tempValue.code;
         value = temperature;
         break;


### PR DESCRIPTION
The colour temperature was inversed so when you picked warm in the ui the lightbulb would turn cold and vice versa. This is because the range of 140-500 in homekit is inverse to the 0-1000 range of the lightbulb, in fact the values 140-500 are micro-reciprocal degrees (mired), which is 1,000,000 divided by the color temperature in kelvins.

I've adjusted the range conversions for colour temperature to convert to and from the range 2000K-14285K which when converted to mireds corresponds to about 70-500 inversed.

I've also added a little trick extending the colour temperature characteristics range to 70-500 in order to show a ui that has a nice orange-blue gradient. Hence I used the values 70-500 in the calculations as well.