### PR TITLE
Fix colorTemperature data and homekit ui demonstrate mismatch

### DIFF
--- a/lib/light_accessory.js
+++ b/lib/light_accessory.js
@@ -137,7 +137,7 @@ class LightAccessory extends BaseAccessory {
         break;
       case Characteristic.ColorTemperature:
         var temperature;
-        temperature = Math.floor((value - 140) * (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) / 360 + this.function_dp_range.temp_range.min); // value 140~500
+        temperature = Math.floor(this.function_dp_range.temp_range.max - (value - 140) * (this.function_dp_range.temp_range.max - this.function_dp_range.temp_range.min) / 360); // value 140~500
         code = this.tempValue.code;
         value = temperature;
         break;


### PR DESCRIPTION
当前版本灯具注册给Homebridge的set回调中，在解析ColorTemperature参数时，Homebridge的参数范围是140(白光)~500(黄光)，而涂鸦iot平台中灯具类目的色温参数范围是0(黄光)~1000(白光)，故存在在homekit app中设置白光时，插件将数据值解析为涂鸦平台的黄光，反之亦然。此处修改数据解析规则，从将原数据映射后加上最小值的计算方法修改为从最大值减去映射后的原数据值。本地测试成功。

https://user-images.githubusercontent.com/34552432/138816766-8d722ff9-c57b-410f-bfa8-84d3a482a2c9.mp4


#136 