### PR TITLE
fix: 🐛 door state misreporting because of string usage

### DIFF
--- a/lib/garagedoor_accessory.js
+++ b/lib/garagedoor_accessory.js
@@ -1,4 +1,4 @@
-const BaseAccessory = require('./base_accessory')
+const BaseAccessory = require('./base_accessory');
 
 let Accessory;
 let Service;
@@ -7,7 +7,6 @@ let UUIDGen;
 
 class GarageDoorAccessory extends BaseAccessory {
   constructor(platform, homebridgeAccessory, deviceConfig) {
-
     ({ Accessory, Characteristic, Service } = platform.api.hap);
     super(
       platform,
@@ -24,46 +23,54 @@ class GarageDoorAccessory extends BaseAccessory {
   //init Or refresh AccessoryService
   refreshAccessoryServiceIfNeed(statusArr, isRefresh) {
     this.isRefresh = isRefresh;
-    for (var statusMap of statusArr) {
-      var rawStatus = statusMap.value
-      let characteristicName
-      let value
+
+    let currentDoorState;
+    let targetDoorState;
+
+    for (let statusMap of statusArr) {
+      const rawStatus = statusMap.value;
       switch (statusMap.code) {
         case 'switch_1':
-          if (rawStatus) {
-            value = '0'
-          } else {
-            value = '1'
-          }
-          characteristicName = Characteristic.TargetDoorState
-          this.initAccessoryCharacteristic(characteristicName, value)
+          targetDoorState = rawStatus
+            ? Characteristic.TargetDoorState.OPEN
+            : Characteristic.TargetDoorState.CLOSED;
           break;
         case 'doorcontact_state':
-          if (rawStatus) {
-            value = '0'
-          } else {
-            value = '1'
-          }
-          characteristicName = Characteristic.CurrentDoorState
-          this.initAccessoryCharacteristic(characteristicName, value)
-          break;
-        case 'countdown_alarm':
-          value = false
-          characteristicName = Characteristic.ObstructionDetected
-          this.initAccessoryCharacteristic(characteristicName, value)
-          break;
-        default:
+          currentDoorState = rawStatus
+            ? Characteristic.CurrentDoorState.OPEN
+            : Characteristic.CurrentDoorState.CLOSED;
           break;
       }
     }
+
+    if (
+      currentDoorState === Characteristic.CurrentDoorState.OPEN &&
+      targetDoorState === Characteristic.TargetDoorState.CLOSED
+    ) {
+      currentDoorState = Characteristic.CurrentDoorState.CLOSING;
+    }
+
+    if (
+      currentDoorState === Characteristic.CurrentDoorState.CLOSED &&
+      targetDoorState === Characteristic.TargetDoorState.OPEN
+    ) {
+      currentDoorState = Characteristic.CurrentDoorState.OPENING;
+    }
+
+    this.initAccessoryCharacteristic(
+      Characteristic.TargetDoorState,
+      targetDoorState
+    );
+    this.initAccessoryCharacteristic(
+      Characteristic.CurrentDoorState,
+      currentDoorState
+    );
   }
 
-  initAccessoryCharacteristic(characteristicName,value){
+  initAccessoryCharacteristic(characteristicName, value) {
     this.setCachedState(characteristicName, value);
     if (this.isRefresh) {
-      this.service
-        .getCharacteristic(characteristicName)
-        .updateValue(value);
+      this.service.getCharacteristic(characteristicName).updateValue(value);
     } else {
       this.getAccessoryCharacteristic(characteristicName);
     }
@@ -71,22 +78,30 @@ class GarageDoorAccessory extends BaseAccessory {
 
   getAccessoryCharacteristic(name) {
     //set  Accessory service Characteristic
-    this.service.getCharacteristic(name)
-      .on('get', callback => {
+    this.service
+      .getCharacteristic(name)
+      .on('get', (callback) => {
         if (this.hasValidCache()) {
           callback(null, this.getCachedState(name));
         }
       })
       .on('set', (value, callback) => {
-        var param = this.getSendParam(name, value)
-        this.platform.tuyaOpenApi.sendCommand(this.deviceId, param).then(() => {
-          this.setCachedState(name, value);
-          callback();
-        }).catch((error) => {
-          this.log.error('[SET][%s] Characteristic.Brightness Error: %s', this.homebridgeAccessory.displayName, error);
-          this.invalidateCache();
-          callback(error);
-        });
+        var param = this.getSendParam(name, value);
+        this.platform.tuyaOpenApi
+          .sendCommand(this.deviceId, param)
+          .then(() => {
+            this.setCachedState(name, value);
+            callback();
+          })
+          .catch((error) => {
+            this.log.error(
+              '[SET][%s] Characteristic.Brightness Error: %s',
+              this.homebridgeAccessory.displayName,
+              error
+            );
+            this.invalidateCache();
+            callback(error);
+          });
       });
   }
 
@@ -97,19 +112,19 @@ class GarageDoorAccessory extends BaseAccessory {
     switch (name) {
       case Characteristic.TargetDoorState:
         const isOn = value == '1' ? false : true;
-        code = "switch_1";
+        code = 'switch_1';
         value = isOn;
         break;
       default:
         break;
     }
     return {
-      "commands": [
+      commands: [
         {
-          "code": code,
-          "value": value
-        }
-      ]
+          code: code,
+          value: value,
+        },
+      ],
     };
   }
 


### PR DESCRIPTION
This is a small fix to ensure that the correct door state is being reported to Homebridge. 