### PR TITLE
removed lines that transform position argument to string

### DIFF
--- a/lib/window_covering_accessory.js
+++ b/lib/window_covering_accessory.js
@@ -107,9 +107,6 @@ class WindowCoveringAccessory extends BaseAccessory {
         if (Characteristic.TargetPosition === name) {
             code = this.percentControlMap.code;
             value = hbParam;
-            if (code === 'position') {
-                value = "" + hbParam;
-            }
         }
         return {
             "commands": [


### PR DESCRIPTION
I ran into [Issue 224](https://github.com/tuya/tuya-homebridge/issues/224), and resolved it by removing the 3 lines below. I tested this against [these curtains](https://www.amazon.com/gp/product/B07X2TDWLN)