### PR TITLE
fix(heater): multiply / divide by 10 to / from Tuya

### DIFF
--- a/lib/heater_accessory.js
+++ b/lib/heater_accessory.js
@@ -226,6 +226,10 @@ class HeaterAccessory extends BaseAccessory {
     for (const funcDic of this.functionArr) {
       let valueRange = JSON.parse(funcDic.values)
       let isnull = (JSON.stringify(valueRange) == "{}")
+      if (!isnull) {
+        valueRange.min = valueRange.min / 10;
+        valueRange.max = valueRange.max / 10;
+      }
       switch (funcDic.code) {
         case 'temp_set':
           tempSetRange = isnull ? { 'min': 0, 'max': 50 } : { 'min': parseInt(valueRange.min), 'max': parseInt(valueRange.max) }


### PR DESCRIPTION
I have only one heater (IR heater from Klarstein) over here, but these changes work for me.

If someone has a heater that already works correctly (where 19°C is displayed as 19°C and not 190°C in Homekit) - let me know, it should be a setting on a higher level then.